### PR TITLE
Add main flashcard trainer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # Flashcard-Trainer
+
 AI-Powered Flashcard App
+
+This repository contains a simple command line flashcard trainer.
+
+## Usage
+
+1. Prepare a JSON file containing your flashcards. Each flashcard must have
+   a `question` and an `answer` field.
+
+Example (`sample_flashcards.json`):
+
+```
+[
+    {"question": "Capital of France", "answer": "Paris"},
+    {"question": "2 + 2", "answer": "4"},
+    {"question": "Largest planet", "answer": "Jupiter"}
+]
+```
+
+2. Run the trainer using Python:
+
+```
+python main.py sample_flashcards.json --shuffle
+```
+
+The program will prompt you with each question and let you know whether your
+answer is correct.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,47 @@
+import argparse
+import json
+import random
+from pathlib import Path
+
+
+def load_flashcards(path: Path):
+    """Load flashcards from a JSON file."""
+    data = json.loads(path.read_text())
+    if not isinstance(data, list):
+        raise ValueError("Flashcard file must contain a list of objects")
+    cards = []
+    for item in data:
+        if not isinstance(item, dict) or 'question' not in item or 'answer' not in item:
+            raise ValueError("Each flashcard must have 'question' and 'answer'")
+        cards.append({'question': str(item['question']), 'answer': str(item['answer'])})
+    return cards
+
+
+def run_quiz(cards):
+    """Run the flashcard quiz."""
+    correct = 0
+    for card in cards:
+        print(f"Q: {card['question']}")
+        user_answer = input("Your answer: ").strip()
+        if user_answer.lower() == card['answer'].lower():
+            print("Correct!\n")
+            correct += 1
+        else:
+            print(f"Incorrect. Answer: {card['answer']}\n")
+    print(f"You answered {correct}/{len(cards)} correctly.")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Simple flashcard trainer")
+    parser.add_argument("file", type=Path, help="Path to JSON file with flashcards")
+    parser.add_argument("--shuffle", action="store_true", help="Shuffle flashcards before starting")
+    args = parser.parse_args(argv)
+
+    cards = load_flashcards(args.file)
+    if args.shuffle:
+        random.shuffle(cards)
+    run_quiz(cards)
+
+
+if __name__ == "__main__":
+    main()

--- a/sample_flashcards.json
+++ b/sample_flashcards.json
@@ -1,0 +1,5 @@
+[
+    {"question": "Capital of France", "answer": "Paris"},
+    {"question": "2 + 2", "answer": "4"},
+    {"question": "Largest planet", "answer": "Jupiter"}
+]


### PR DESCRIPTION
## Summary
- implement `main.py` as a simple command line flashcard trainer
- provide example `sample_flashcards.json`
- update README with usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c99475d883319283aa963118813c